### PR TITLE
Made robust vs whole-chromosome blacklisting

### DIFF
--- a/wisecondorX/include/CBS.R
+++ b/wisecondorX/include/CBS.R
@@ -74,12 +74,23 @@ for (chr in chrs){
 for.cbs$chromosome <- chr.rep; for.cbs$x <- chr.rep.2
 for.cbs <- for.cbs[, c(2,3,1)] ; colnames(for.cbs)[3] <- "y"
 
+# Check for complete NA/chr
+
+cbs.mask <- c()
+for (chr in chrs){
+    check <- which(for.cbs$chromosome == chr)
+    if(!(all(is.na(for.cbs$y[check])))){
+        cbs.mask <- c(cbs.mask, check)
+    }
+}
+for.cbs <- for.cbs[cbs.mask,]
+
 # CBS
 
 CNA.object <- CNA(for.cbs$y, for.cbs$chromosome, for.cbs$x, data.type = "logratio", sampleid = "X")
 f = file()
 sink(file=f) ## silence output
-CNA.object <- invisible(segment(CNA.object, alpha = as.numeric(alpha), verbose=1, weights=weights)$output)
+CNA.object <- invisible(segment(CNA.object, alpha = as.numeric(alpha), verbose=1, weights=weights[cbs.mask])$output)
 sink() ## undo silencing
 close(f)
 

--- a/wisecondorX/wisetools.py
+++ b/wisecondorX/wisetools.py
@@ -480,7 +480,7 @@ def generate_txt_output(args, json_out):
 
     segments_file.close()
 
-    statistics_file = open(args.outid + "_statistics.txt", "w")
+    statistics_file = open(args.outid + "_chr_statistics.txt", "w")
     statistics_file.write("chr\tzscore\tratio.mean\tratio.median\n")
     chrom_scores = []
     for chr_i in range(len(results_r)):
@@ -504,7 +504,8 @@ def generate_txt_output(args, json_out):
                               + "\n")
         chrom_scores.append(chrom_ratio_mean)
 
-    statistics_file.write("Standard deviation mean chromosomal ratio: " + str(np.std(chrom_scores)) + "\n")
+    statistics_file.write("Standard deviation mean chromosomal ratio: " +
+                          str(np.std([x for x in chrom_scores if not np.isnan(x)])) + "\n")
     statistics_file.write("Median within-segment binwise ratio variance: " + str(
         get_median_within_segment_variance(segments, results_r)) + "\n")
     statistics_file.close()
@@ -544,7 +545,7 @@ def get_median_within_segment_variance(segments, binratios):
         if [] != segment_ratios:
             var = np.var(segment_ratios)
             vars.append(var)
-    return np.median(vars)
+    return np.median([x for x in vars if not np.isnan(x)])
 
 
 def apply_blacklist(args, binsize, results_r, results_z, results_w, sample, gender):


### PR DESCRIPTION
Goal: stop mails concerning "AttributeError: 'NoneType' object has no attribute 'encode'" resulting from reference creation with male + female samples