### PR TITLE
V1.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 from setuptools import setup, find_packages
 
-version = '1.1.0dev'
+version = '1.1.1'
 dl_version = 'master' if 'dev' in version else '{}'.format(version)
 
 setup(

--- a/wisecondorX/include/plotter.R
+++ b/wisecondorX/include/plotter.R
@@ -201,7 +201,7 @@ par(xpd=F)
 par(xpd=NA)
 legend(x=chr.ends[length(chr.ends)] * 0.3,
        y=chr.wide.upper.limit + (abs(chr.wide.upper.limit) + abs(chr.wide.lower.limit)) * 0.23,
-       legend=c("Constitutional triploid", "Constitutional diploid", "Constitutional monoploid"),
+       legend=c("Constitutional 3n", "Constitutional 2n", "Constitutional 1n"),
        text.col=color.X, cex=1.3, bty="n", lty=c(3,3,3), lwd=1.5, col=color.X)
 legend(x=0,
        y=chr.wide.upper.limit + (abs(chr.wide.upper.limit) + abs(chr.wide.lower.limit)) * 0.23,

--- a/wisecondorX/main.py
+++ b/wisecondorX/main.py
@@ -203,15 +203,8 @@ def tool_test(args):
     results_w = results_w / np.nanmedian(results_w)
     ref_sizes = np.append(ref_sizes, ref_sizes_2)
 
-    null_ratios_aut_per_sample = np.transpose(null_ratios_aut_per_bin)
-    part_mask = np.array(
-        [not x for x in list(np.isnan(results_r))], dtype=bool)
-    null_m_lr_aut = np.array([np.nanmedian(x[part_mask[:len(null_ratios_aut_per_bin)]])
-                              for x in null_ratios_aut_per_sample])
-
     null_ratios = np.array(
         [x.tolist() for x in null_ratios_aut_per_bin] + [x.tolist() for x in null_ratios_gon_per_bin])
-    null_ratios = null_ratios - null_m_lr_aut
 
     results = {'results_r': results_r,
                'results_z': results_z,

--- a/wisecondorX/main.py
+++ b/wisecondorX/main.py
@@ -209,9 +209,9 @@ def tool_test(args):
     null_m_lr_aut = np.array([np.nanmedian(x[part_mask[:len(null_ratios_aut_per_bin)]])
                               for x in null_ratios_aut_per_sample])
 
-    null_ratios_aut_per_bin = null_ratios_aut_per_bin - null_m_lr_aut
     null_ratios = np.array(
         [x.tolist() for x in null_ratios_aut_per_bin] + [x.tolist() for x in null_ratios_gon_per_bin])
+    null_ratios = null_ratios - null_m_lr_aut
 
     results = {'results_r': results_r,
                'results_z': results_z,

--- a/wisecondorX/overall_tools.py
+++ b/wisecondorX/overall_tools.py
@@ -92,7 +92,9 @@ def get_z_score(results_c, results):
         segment_w = results_w[segment[0]][segment[1]:segment[2]]
         segment_w = [segment_w[i] for i in range(len(segment_w)) if segment_rr[i] != 0]
         null_segments = [np.ma.average(x, weights=segment_w) for x in np.transpose(segment_nr)]
-        zs.append(segment[3] / np.ma.std([x for x in null_segments if np.isfinite(x)]))
+        null_mean = np.ma.mean([x for x in null_segments if np.isfinite(x)])
+        null_sd = np.ma.std([x for x in null_segments if np.isfinite(x)])
+        zs.append((segment[3] - null_mean) / null_sd)
     return zs
 
 


### PR DESCRIPTION
- Z-score now (X-u)/sd instead of X/sd
- Terminology update: 'diploid' -> '2n', which is more appropriate
- Bugfix null set median centering