### PR TITLE
Add VCF support

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,10 @@ WisecondorX predict test_input.npz reference_input.npz output_id [--optional arg
 `--beta x` | When beta is given, `--zscore` is ignored. Beta sets a ratio cutoff for aberration calling. It's a number between 0 (liberal) and 1 (conservative) and, when used, is optimally close to the purity (e.g. fetal/tumor fraction)  
 `--blacklist x` | Blacklist for masking additional regions; requires headerless .bed file. This is particularly useful when the reference set is too small to recognize some obvious loci (such as centromeres; examples at `./example.blacklist/`)  
 `--gender x` | Force WisecondorX to analyze this case as male (M) or female (F). Useful when e.g. dealing with a loss of chromosome Y, which causes erroneous gender predictions (choices: x=F or x=M)
-`--bed` | Outputs tab-delimited .bed files (trisomy 21 NIPT example at `./example.bed`), containing all necessary information  **(\*)**  
+`--bed` | Outputs tab-delimited .bed files (trisomy 21 NIPT example at `./example.bed`), containing all necessary information  **(\*)** 
+`--vcf` | Outputs the found CNVs in a .vcf file (default: False)
+`--fai FAI` | The index of the reference used to align the input files. (Only needed for VCF creation) (default: None)
+`--sample SAMPLE` | The sample name to use in the VCF. Defaults to the basename of the out ID. (default: None) 
 `--plot` | Outputs custom .png plots (trisomy 21 NIPT example at `./example.plot`), directly interpretable  **(\*)**  
 `--ylim [a,b]` | Force WisecondorX to use y-axis interval [a,b] during plotting, e.g. [-2,2]  
 `--cairo` | Some operating systems require the cairo bitmap type to write plots  

--- a/wisecondorX/main.py
+++ b/wisecondorX/main.py
@@ -239,9 +239,9 @@ def tool_test(args):
 
     results['results_c'] = exec_cbs(rem_input, results)
 
-    if args.bed:
+    if args.bed or args.vcf:
         logging.info('Writing tables ...')
-        generate_output_tables(rem_input, results)
+        generate_output_tables(rem_input, results, args.bed, args.vcf)
 
     if args.plot:
         logging.info('Writing plots ...')
@@ -390,6 +390,9 @@ def main():
     parser_test.add_argument('--bed',
                              action='store_true',
                              help='Outputs tab-delimited .bed files, containing the most important information')
+    parser_test.add_argument('--vcf',
+                             action='store_true',
+                             help='Outputs the found CNVs in a .vcf file')
     parser_test.add_argument('--plot',
                              action='store_true',
                              help='Outputs .png plots')

--- a/wisecondorX/main.py
+++ b/wisecondorX/main.py
@@ -121,9 +121,14 @@ def tool_newref(args):
 def tool_test(args):
     logging.info('Starting CNA prediction')
 
-    if not args.bed and not args.plot:
+    if not args.bed and not args.plot and not args.vcf:
         logging.critical('No output format selected. '
-                         'Select at least one of the supported output formats (--bed, --plot)')
+                         'Select at least one of the supported output formats (--bed, --plot, --vcf)')
+        sys.exit()
+
+    if args.vcf and not args.fai:
+        logging.critical('A fasta index file is needed to create a VCF file. '
+                         'Please provide one via the --fai flag')
         sys.exit()
 
     if args.zscore <= 0:
@@ -240,8 +245,11 @@ def tool_test(args):
     results['results_c'] = exec_cbs(rem_input, results)
 
     if args.bed or args.vcf:
-        logging.info('Writing tables ...')
-        generate_output_tables(rem_input, results, args.bed, args.vcf)
+        types = []
+        if args.bed: types.append("tables")
+        if args.vcf: types.append("VCF")
+        logging.info("Writing {} ...".format("/".join(types)))
+        generate_output_tables(rem_input, results)
 
     if args.plot:
         logging.info('Writing plots ...')
@@ -393,6 +401,12 @@ def main():
     parser_test.add_argument('--vcf',
                              action='store_true',
                              help='Outputs the found CNVs in a .vcf file')
+    parser_test.add_argument('--fai',
+                             type=str,
+                             help='The index of the reference used to align the input files. (Only needed for VCF creation)')
+    parser_test.add_argument('--sample',
+                             type=str,
+                             help='The sample name to use in the VCF. Defaults to the basename of the out ID.')
     parser_test.add_argument('--plot',
                              action='store_true',
                              help='Outputs .png plots')


### PR DESCRIPTION
Adds #105 

Adds 3 new options to the `predict` command:
1. `--vcf` to state that a VCF file should be created (Will create a bgzipped vcf file)
2. `--fai` to create the contigs in the VCF header
3. `--sample` to set the sample name to be used in the VCF. This will default to the basename of the `outid`

The VCF header looks like this:
```
##fileformat=VCFv4.2
##FILTER=<ID=PASS,Description="All filters passed">
##contig=<ID=chr1,length=248956422>
...
##contig=<ID=chrUn_JTFH01001998v1_decoy,length=2001>
##ALT=<ID=CNV,Description="Copy number variant region">
##ALT=<ID=DEL,Description="Deletion relative to the reference">
##ALT=<ID=DUP,Description="Region of elevated copy number relative to the reference">
##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles">
##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the variant described in this record">
##FILTER=<ID=cnvQual,Description="CNV with quality below 10">
##FILTER=<ID=cnvCopyRatio,Description="CNV with copy ratio within +/- 0.2 of 1.0">
##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
##FORMAT=<ID=SM,Number=1,Type=Float,Description="Linear copy ratio of the segment mean">
##FORMAT=<ID=ZS,Number=1,Type=Float,Description="The z-score calculated for the current CNV">
#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Sample
```

And the variants themselves will look like this:
```
chr1	6260002	WisecondorX_DUP_4	N	<DUP>	.	.	END=6280000;SVTYPE=CNV;SVLEN=20000	GT:SM:ZS	./.:1.0289:6.62867
chr1	6515002	WisecondorX_DEL_1	N	<DEL>	.	.	END=6895000;SVTYPE=CNV;SVLEN=380000	GT:SM:ZS	./.:-0.2654:-5.26266
```