### PR TITLE
fix numpy error

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,5 +193,6 @@ the 'ID_segments.bed'. Particularly interesting for NIPT.
   - pysam (v0.22.0)
   - numpy (v1.26.4)
   - matplotlib (v3.8.4)
+  - pandas
 
 And of course, other versions are very likely to work as well.

--- a/README.md
+++ b/README.md
@@ -193,6 +193,6 @@ the 'ID_segments.bed'. Particularly interesting for NIPT.
   - pysam (v0.22.0)
   - numpy (v1.26.4)
   - matplotlib (v3.8.4)
-  - pandas
+  - pandas (2.2.2)
 
 And of course, other versions are very likely to work as well.

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ install_requires =
     scikit-learn
     pysam
     numpy
+    pandas
 zip_safe = False
 
 [options.entry_points]

--- a/src/wisecondorx/overall_tools.py
+++ b/src/wisecondorx/overall_tools.py
@@ -8,6 +8,7 @@ import sys
 import math
 
 import numpy as np
+import pandas as pd
 
 """
 Scales the bin size of a sample.npz to the one  
@@ -104,7 +105,7 @@ def get_z_score(results_c, results):
         segment_w = results_w[segment[0]][segment[1] : segment[2]]
         segment_w = [segment_w[i] for i in range(len(segment_w)) if segment_rr[i] != 0]
         null_segments = [
-            np.ma.average(np.ma.masked_array(x, np.isnan(x)), weights=segment_w)
+            np.ma.average(np.ma.masked_array(x, pd.isnull(x)), weights=segment_w)
             for x in np.transpose(segment_nr)
         ]
         null_mean = np.ma.mean([x for x in null_segments if np.isfinite(x)])


### PR DESCRIPTION
This creates a fix for the TypeError in 1.2.7

TypeError: ufunc 'isnan' not supported for the input types.