### PR TITLE
Fix predict maskrepeats compatibility by relaxing PCA outlier filtering

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -4042,7 +4042,7 @@ packages:
 - pypi: ./
   name: wisecondorx
   version: 1.3.1
-  sha256: 2e010862784bc577d7afd3bd2ab34836f2f8949d777ccea77b4d86e76498414b
+  sha256: 8913b9d7810ea68bc7831a166d21cac3459e3fd4d8a318460d12ec0e6a1decec
   requires_dist:
   - scipy>=1.17
   - scikit-learn>=1.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,4 +96,4 @@ test = { features = ["test"], solve-group = "default" }
 lint = { cmd = "ruff check src/"}
 test = { cmd = "PYTHONPATH=. pytest tests/", default-environment = "test" }
 format = { cmd = "ruff format src/"}
-docker-build = "docker build --platform linux/amd64 -t cmgg/wisecondorx:latest ."
+docker-build = "docker build --platform linux/amd64 -t quay.io/cmgg/wisecondorx:latest ."

--- a/src/wisecondorx/newref_control.py
+++ b/src/wisecondorx/newref_control.py
@@ -26,6 +26,12 @@ for XY gonosomes (if enough males are included).
 
 
 def _robust_cutoff(distances, mad_multiplier, floor):
+    """
+    Computes a robust distance cutoff to remove unmatchable bins.
+    
+    :param mad_multiplier: Multiplier applied to the median absolute deviation (MAD).
+    :param floor: Absolute minimum value for the cutoff.
+    """
     med = np.median(distances)
     mad = np.median(np.abs(distances - med))
     return max(med + mad_multiplier * mad, floor)
@@ -55,9 +61,9 @@ def tool_newref_prep(args, samples, gender, mask, bins_per_chr):
     masked_indices, masked_chr_ids = _masked_chr_ids(mask, bins_per_chr)
     bad_bins_mask = np.zeros(len(masked_indices), dtype=bool)
 
-    # PCA Distance filtering (via _robust_cutoff): remove unmatchable bins far from median profile.
-    # Higher MAD multipliers (20.0-50.0) retain natural variance so predict works on shallow samples.
-    # The hard floor (10.0-15.0) prevents over-trimming if the training dataset is exceptionally clean.
+    # PCA Distance filtering: we use higher MAD multipliers (20.0-50.0) and floors (10.0-15.0) 
+    # than typical outlier detection to ensure the reference retains enough natural variance 
+    # to prevent massive NaN gaps when `predict` runs on shallower, noisier routine samples.
     if gender == "A":
         class_settings = [("autosomes", masked_chr_ids <= 22, 20.0, 10.0)]
     elif gender == "F":

--- a/src/wisecondorx/newref_control.py
+++ b/src/wisecondorx/newref_control.py
@@ -38,6 +38,10 @@ def _robust_cutoff(distances, mad_multiplier, floor):
 
 
 def _masked_chr_ids(mask, bins_per_chr):
+    """
+    Maps each `True` index in the 1D mask back to its 1-based chromosome ID.
+    Used to split PCA distance filtering thresholds by chromosome class.
+    """
     masked_indices = np.where(mask)[0]
     chr_ends = np.cumsum(bins_per_chr)
     chr_ids = np.searchsorted(chr_ends, masked_indices, side="right") + 1
@@ -61,9 +65,14 @@ def tool_newref_prep(args, samples, gender, mask, bins_per_chr):
     masked_indices, masked_chr_ids = _masked_chr_ids(mask, bins_per_chr)
     bad_bins_mask = np.zeros(len(masked_indices), dtype=bool)
 
-    # PCA Distance filtering: we use higher MAD multipliers (20.0-50.0) and floors (10.0-15.0) 
-    # than typical outlier detection to ensure the reference retains enough natural variance 
-    # to prevent massive NaN gaps when `predict` runs on shallower, noisier routine samples.
+    # PCA Distance filtering: calculate outlier thresholds independently per chromosome class.
+    # This prevents the noisier chrX/chrY from being heavily pruned when judged against an 
+    # autosome-dominated median profile.
+    # 
+    # We use higher MAD multipliers (20.0-50.0) and floors (10.0-15.0) 
+    # than typical outlier detection to ensure the reference retains 
+    # enough natural variance to prevent massive NaN gaps when `predict` runs on shallower, 
+    # noisier routine samples.
     if gender == "A":
         class_settings = [("autosomes", masked_chr_ids <= 22, 20.0, 10.0)]
     elif gender == "F":

--- a/src/wisecondorx/newref_control.py
+++ b/src/wisecondorx/newref_control.py
@@ -55,6 +55,9 @@ def tool_newref_prep(args, samples, gender, mask, bins_per_chr):
     masked_indices, masked_chr_ids = _masked_chr_ids(mask, bins_per_chr)
     bad_bins_mask = np.zeros(len(masked_indices), dtype=bool)
 
+    # PCA Distance filtering (via _robust_cutoff): remove unmatchable bins far from median profile.
+    # Higher MAD multipliers (20.0-50.0) retain natural variance so predict works on shallow samples.
+    # The hard floor (10.0-15.0) prevents over-trimming if the training dataset is exceptionally clean.
     if gender == "A":
         class_settings = [("autosomes", masked_chr_ids <= 22, 20.0, 10.0)]
     elif gender == "F":

--- a/src/wisecondorx/newref_control.py
+++ b/src/wisecondorx/newref_control.py
@@ -28,7 +28,7 @@ for XY gonosomes (if enough males are included).
 def _robust_cutoff(distances, mad_multiplier, floor):
     """
     Computes a robust distance cutoff to remove unmatchable bins.
-    
+
     :param mad_multiplier: Multiplier applied to the median absolute deviation (MAD).
     :param floor: Absolute minimum value for the cutoff.
     """
@@ -66,12 +66,12 @@ def tool_newref_prep(args, samples, gender, mask, bins_per_chr):
     bad_bins_mask = np.zeros(len(masked_indices), dtype=bool)
 
     # PCA Distance filtering: calculate outlier thresholds independently per chromosome class.
-    # This prevents the noisier chrX/chrY from being heavily pruned when judged against an 
+    # This prevents the noisier chrX/chrY from being heavily pruned when judged against an
     # autosome-dominated median profile.
-    # 
-    # We use higher MAD multipliers (20.0-50.0) and floors (10.0-15.0) 
-    # than typical outlier detection to ensure the reference retains 
-    # enough natural variance to prevent massive NaN gaps when `predict` runs on shallower, 
+    #
+    # We use higher MAD multipliers (20.0-50.0) and floors (10.0-15.0)
+    # than typical outlier detection to ensure the reference retains
+    # enough natural variance to prevent massive NaN gaps when `predict` runs on shallower,
     # noisier routine samples.
     if gender == "A":
         class_settings = [("autosomes", masked_chr_ids <= 22, 20.0, 10.0)]

--- a/src/wisecondorx/newref_control.py
+++ b/src/wisecondorx/newref_control.py
@@ -56,13 +56,13 @@ def tool_newref_prep(args, samples, gender, mask, bins_per_chr):
     bad_bins_mask = np.zeros(len(masked_indices), dtype=bool)
 
     if gender == "A":
-        class_settings = [("autosomes", masked_chr_ids <= 22, 10.0, 5.0)]
+        class_settings = [("autosomes", masked_chr_ids <= 22, 20.0, 10.0)]
     elif gender == "F":
-        class_settings = [("chrX", masked_chr_ids == 23, 10.0, 5.0)]
+        class_settings = [("chrX", masked_chr_ids == 23, 20.0, 10.0)]
     else:
         class_settings = [
-            ("chrX", masked_chr_ids == 23, 10.0, 5.0),
-            ("chrY", masked_chr_ids == 24, 20.0, 5.0),
+            ("chrX", masked_chr_ids == 23, 20.0, 10.0),
+            ("chrY", masked_chr_ids == 24, 50.0, 15.0),
         ]
     for class_name, class_mask, mad_mult, floor in class_settings:
         if np.sum(class_mask) < 10:

--- a/tests/test_newref_contract.py
+++ b/tests/test_newref_contract.py
@@ -117,8 +117,8 @@ class TestNewrefContract(unittest.TestCase):
         autosome_outlier = 5
         chry_start = int(np.sum(bins_per_chr[:23]))
         chry_outlier = chry_start + 5
-        vals[autosome_outlier] = 7.0
-        vals[chry_outlier] = 7.0
+        vals[autosome_outlier] = 10.0
+        vals[chry_outlier] = 10.0
         pca_first = np.stack([vals, np.zeros(total_bins, dtype=float)], axis=1)
 
         call_count = {"n": 0}
@@ -184,7 +184,7 @@ class TestNewrefContract(unittest.TestCase):
             total_bins,
         )
         autosome_outlier = 5
-        vals[autosome_outlier] = 7.0
+        vals[autosome_outlier] = 10.0
         pca_first = np.stack([vals, np.zeros(total_bins, dtype=float)], axis=1)
 
         call_count = {"n": 0}


### PR DESCRIPTION
The previous, overly strict filters artificially tightened the reference distance distribution, causing the dynamic predict cutoff to discard natural biological variance in shallow samples. This retains natural variance so predict can safely use standard dynamic filtering (e.g., --maskrepeats 2 ...) to clear noise without dropping valid regions.